### PR TITLE
Fix Nekojishi website uri

### DIFF
--- a/games/Nekojishi.yaml
+++ b/games/Nekojishi.yaml
@@ -56,7 +56,7 @@ tags:
 
 links:
   - name: .website
-    uri: https://nekojishi.games/
+    uri: https://www.klondike.studio/
   - name: .steam
     uri: steam:570840
   - name: .itch.io


### PR DESCRIPTION
The original URI points to an empty page
The new URL points to the website of the game developer Studio Klondike